### PR TITLE
fix typo in pytest.lua

### DIFF
--- a/lua/pytest.lua
+++ b/lua/pytest.lua
@@ -20,7 +20,7 @@ function pytest.setup(opts)
       vim.tbl_isempty(
         vim.fs.find(
           opts["testDir"],
-          { path = vim.loop.cwd(), type = "direcotry", stop = "yes" }
+          { path = vim.loop.cwd(), type = "directory", stop = "yes" }
         )
       ) ~= true
     then


### PR DESCRIPTION
Fix a typo in the pytest.lua file. Hope it helps. Thanks

![Open Source Saturday Italy](https://img.shields.io/badge/Open%20Source%20Saturday-Italy-red)